### PR TITLE
Wrapper for Filesystem->rename()

### DIFF
--- a/src/Bravo3/ImageManager/Services/ImageManager.php
+++ b/src/Bravo3/ImageManager/Services/ImageManager.php
@@ -308,7 +308,7 @@ class ImageManager
      * @param string             $key
      * @param ImageMetadata|null $metadata
      *
-     * @return null
+     * @return $this
      */
     protected function tag($key, ImageMetadata $metadata = null)
     {
@@ -325,6 +325,8 @@ class ImageManager
         }
 
         $item->set($value, null);
+
+        return $this;
     }
 
     /**
@@ -332,7 +334,7 @@ class ImageManager
      *
      * @param string $key
      *
-     * @return void
+     * @return $this
      */
     protected function untag($key)
     {
@@ -342,6 +344,8 @@ class ImageManager
 
         $item = $this->cache_pool->getItem('remote.'.$key);
         $item->delete();
+
+        return $this;
     }
 
     /**
@@ -591,14 +595,18 @@ class ImageManager
     /**
      * Rename a file
      *
-     * @param string $sourceKey
-     * @param string $targetKey
+     * @param string $source_key
+     * @param string $target_key
+     *
+     * @return $this
      */
-    public function rename($sourceKey, $targetKey)
+    public function rename($source_key, $target_key)
     {
-        $this->filesystem->rename($sourceKey, $targetKey);
+        $this->filesystem->rename($source_key, $target_key);
+        
+        return $this;
     }
-    
+
     /**
      * Check with the filesystem if the image exists and update the image key cache.
      *

--- a/src/Bravo3/ImageManager/Services/ImageManager.php
+++ b/src/Bravo3/ImageManager/Services/ImageManager.php
@@ -598,8 +598,7 @@ class ImageManager
     {
         $this->filesystem->rename($sourceKey, $targetKey);
     }
-
-
+    
     /**
      * Check with the filesystem if the image exists and update the image key cache.
      *

--- a/src/Bravo3/ImageManager/Services/ImageManager.php
+++ b/src/Bravo3/ImageManager/Services/ImageManager.php
@@ -305,8 +305,10 @@ class ImageManager
      * If metadata object is populated, that metadata will be stored
      * against the image tag stored in the cache layer.
      *
-     * @param string        $key
-     * @param ImageMetadata $metadata
+     * @param string             $key
+     * @param ImageMetadata|null $metadata
+     *
+     * @return null
      */
     protected function tag($key, ImageMetadata $metadata = null)
     {
@@ -328,7 +330,9 @@ class ImageManager
     /**
      * Mark a file as absent on the remote.
      *
-     * @param string $key
+     * @param $key
+     *
+     * @return null
      */
     protected function untag($key)
     {
@@ -454,12 +458,16 @@ class ImageManager
     /**
      * Create a new image variation from a local source image.
      *
-     * @param Image           $source
-     * @param ImageFormat     $format
-     * @param int             $quality
-     * @param ImageDimensions $dimensions
+     * @param Image                    $source
+     * @param ImageFormat              $format
+     * @param int                      $quality
+     * @param ImageDimensions|null     $dimensions
+     * @param ImageCropDimensions|null $crop_dimensions
      *
      * @return ImageVariation
+     *
+     * @throws ImageManagerException
+     * @throws NoSupportedEncoderException
      */
     public function createVariation(
         Image $source,
@@ -476,10 +484,12 @@ class ImageManager
     /**
      * Create a new image from a filename and hydrate it.
      *
-     * @param string $filename
-     * @param string $key
+     * @param string      $filename
+     * @param string|null $key
      *
      * @return Image
+     *
+     * @throws IoException
      */
     public function loadFromFile($filename, $key = null)
     {
@@ -577,6 +587,18 @@ class ImageManager
 
         return $this;
     }
+
+    /**
+     * Rename a file
+     *
+     * @param string $sourceKey
+     * @param string $targetKey
+     */
+    public function rename($sourceKey, $targetKey)
+    {
+        $this->filesystem->rename($sourceKey, $targetKey);
+    }
+
 
     /**
      * Check with the filesystem if the image exists and update the image key cache.

--- a/src/Bravo3/ImageManager/Services/ImageManager.php
+++ b/src/Bravo3/ImageManager/Services/ImageManager.php
@@ -330,9 +330,9 @@ class ImageManager
     /**
      * Mark a file as absent on the remote.
      *
-     * @param $key
+     * @param string $key
      *
-     * @return null
+     * @return void
      */
     protected function untag($key)
     {


### PR DESCRIPTION
Added wrapper for Renaming a file to fix the Wordpress issues with duplicated images.