### PR TITLE
Fix tag on rename

### DIFF
--- a/src/Bravo3/ImageManager/Services/ImageManager.php
+++ b/src/Bravo3/ImageManager/Services/ImageManager.php
@@ -608,12 +608,13 @@ class ImageManager
     {
         $this->filesystem->rename($source_key, $target_key);
 
+        $metadata = null;
         if ($this->tagExists($source_key)) {
             $metadata = $this->getMetadata($source_key);
-
-            $this->tag($target_key, $metadata);
             $this->untag($source_key);
         }
+
+        $this->tag($target_key, $metadata);
 
         return $this;
     }

--- a/src/Bravo3/ImageManager/Services/ImageManager.php
+++ b/src/Bravo3/ImageManager/Services/ImageManager.php
@@ -198,7 +198,7 @@ class ImageManager
         // for the metadata.
         if ($image instanceof ImageVariation) {
             $img_key = $image->getKey(true);
-        } elseif ($image instanceof ImageVariation) {
+        } elseif ($image instanceof Image) {
             $img_key = $image->getKey();
         } else {
             $img_key = $image;

--- a/src/Bravo3/ImageManager/Services/ImageManager.php
+++ b/src/Bravo3/ImageManager/Services/ImageManager.php
@@ -188,18 +188,20 @@ class ImageManager
     /**
      * Get meta information about the source image from the cache layer.
      *
-     * @param Image $image
+     * @param Image|string $image
      *
      * @return ImageMetadata
      */
-    public function getMetadata(Image $image)
+    public function getMetadata($image)
     {
         // If the $image is a variation, refer to its parent
         // for the metadata.
         if ($image instanceof ImageVariation) {
             $img_key = $image->getKey(true);
-        } else {
+        } elseif ($image instanceof ImageVariation) {
             $img_key = $image->getKey();
+        } else {
+            $img_key = $image;
         }
 
         // Retrieve from cache array if image metadata exists
@@ -595,6 +597,8 @@ class ImageManager
     /**
      * Rename a file
      *
+     * TODO: Potentially fix https://github.com/KnpLabs/Gaufrette/issues/374 here.
+     *
      * @param string $source_key
      * @param string $target_key
      *
@@ -603,7 +607,14 @@ class ImageManager
     public function rename($source_key, $target_key)
     {
         $this->filesystem->rename($source_key, $target_key);
-        
+
+        if ($this->tagExists($source_key)) {
+            $metadata = $this->getMetadata($source_key);
+
+            $this->tag($target_key, $metadata);
+            $this->untag($source_key);
+        }
+
         return $this;
     }
 

--- a/tests/Bravo3/ImageManager/Tests/Services/ImageManagerTest.php
+++ b/tests/Bravo3/ImageManager/Tests/Services/ImageManagerTest.php
@@ -107,6 +107,27 @@ class ImageManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($im->exists($image_a));
     }
 
+    public function testRenamedAssetIsPersistent()
+    {
+        $fn = __DIR__.'/../Resources/image.png';
+        $im = new ImageManager(new Filesystem(new LocalAdapter(static::$tmp_dir.'remote')), new EphemeralCachePool());
+
+        $image = $im->loadFromFile($fn, self::TEST_KEY);
+        $im->push($image);
+
+        $original_key = $image->getKey();
+        $new_key      = '/tmp/some-new-key';
+
+        $im->rename($original_key, $new_key);
+
+        $renamed = new Image($new_key);
+
+        $im->pull($renamed);
+
+        $this->assertTrue($renamed->isHydrated());
+        $this->assertTrue($renamed->isPersistent());
+    }
+
     /**
      * @expectedException \Bravo3\ImageManager\Exceptions\NotExistsException
      * @medium


### PR DESCRIPTION
Not sure I like removing the Image type hint but it seemed like the easiest way to get the metadata from the original image (by key). This shouldn't have any BC side effects though.
